### PR TITLE
feat: Setting up schedules for a specialist

### DIFF
--- a/project-e-dukate-frontend/package-lock.json
+++ b/project-e-dukate-frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@mui/icons-material": "^7.0.1",
         "@mui/lab": "^7.0.0-beta.10",
         "@mui/material": "^7.0.1",
-        "@mui/x-date-pickers": "^7.28.2",
+        "@mui/x-date-pickers": "^7.29.1",
         "dayjs": "^1.11.13",
         "next": "15.2.4",
         "react": "^19.0.0",
@@ -21,6 +21,7 @@
         "react-icons": "^5.5.0",
         "react-toastify": "^11.0.5",
         "sass": "^1.86.2",
+        "slugify": "^1.6.6",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -1260,14 +1261,14 @@
       "license": "MIT"
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.28.2.tgz",
-      "integrity": "sha512-py8u0iOShM8m/Ocs/giS8MwTNFn+iRFG6m5L6YJ/JmKzNfQfkVJOjpbdSIWxdCJ8plJn95oar1nKUhDdwn88HA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.29.1.tgz",
+      "integrity": "sha512-0RibuJ1YOgUVNqS4aSIXmxpqZ5YWLsxSM84GFlm3M7WW8UbwBY2QzG4vcOsLOYUwk2aqhcP6cpnrIyoLYUsS7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-        "@mui/x-internals": "7.28.0",
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0",
+        "@mui/x-internals": "7.29.0",
         "@types/react-transition-group": "^4.4.11",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -1283,8 +1284,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta",
+        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
         "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
         "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
         "dayjs": "^1.10.7",
@@ -1326,13 +1327,13 @@
       }
     },
     "node_modules/@mui/x-internals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.28.0.tgz",
-      "integrity": "sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.29.0.tgz",
+      "integrity": "sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+        "@mui/utils": "^5.16.6 || ^6.0.0 || ^7.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5975,6 +5976,15 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map": {

--- a/project-e-dukate-frontend/package.json
+++ b/project-e-dukate-frontend/package.json
@@ -14,7 +14,7 @@
     "@mui/icons-material": "^7.0.1",
     "@mui/lab": "^7.0.0-beta.10",
     "@mui/material": "^7.0.1",
-    "@mui/x-date-pickers": "^7.28.2",
+    "@mui/x-date-pickers": "^7.29.1",
     "dayjs": "^1.11.13",
     "next": "15.2.4",
     "react": "^19.0.0",
@@ -22,6 +22,7 @@
     "react-icons": "^5.5.0",
     "react-toastify": "^11.0.5",
     "sass": "^1.86.2",
+    "slugify": "^1.6.6",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/project-e-dukate-frontend/src/app/dashboard/horarios/[slug]/page.tsx
+++ b/project-e-dukate-frontend/src/app/dashboard/horarios/[slug]/page.tsx
@@ -1,0 +1,5 @@
+import { ScheduleEdit } from '@/pages/Schedules';
+
+export default function ScheduleEditPage() {
+  return <ScheduleEdit />;
+}

--- a/project-e-dukate-frontend/src/components/ScheduleDay/ScheduleDay.tsx
+++ b/project-e-dukate-frontend/src/components/ScheduleDay/ScheduleDay.tsx
@@ -1,0 +1,96 @@
+// src/components/ScheduleDay/ScheduleDay.tsx
+import React from "react";
+import { Box, Typography, FormControlLabel, Checkbox, IconButton } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import { TimeSlotEditor } from "../TimeSlotEditor";
+import { ScheduleDto } from "@/types/schedule";
+import { daysOfWeek } from "@/utils/scheduleUtils";
+import { Dayjs } from "dayjs";
+import { canAddTimeSlot } from "@/utils/scheduleUtils";
+
+interface ScheduleDayProps {
+  schedule: ScheduleDto;
+  dayIndex: number;
+  onAttendsChange: (dayIndex: number, checked: boolean) => void;
+  onTimeChange: (
+    dayIndex: number,
+    slotIndex: number,
+    field: "startTime" | "endTime",
+    value: Dayjs | null
+  ) => void;
+  onAddTimeSlot: (dayIndex: number) => void;
+  onRemoveTimeSlot: (dayIndex: number, slotIndex: number) => void;
+}
+
+export const ScheduleDay: React.FC<ScheduleDayProps> = ({
+  schedule,
+  dayIndex,
+  onAttendsChange,
+  onTimeChange,
+  onAddTimeSlot,
+  onRemoveTimeSlot,
+}) => {
+  const canAdd = canAddTimeSlot(schedule.timeSlots);
+
+  return (
+    <Box
+      sx={{
+        px: 6,
+        py: 3,
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: schedule.attends ? "flex-start" : "center",
+        borderBottom:
+          dayIndex < daysOfWeek.length - 1 ? "1px solid #e0e0e0" : "none",
+        bgcolor: "white",
+      }}
+    >
+      <Box sx={{ display: "flex", flexDirection: "column", width: "330px" }}>
+        <Typography
+          variant="subtitle1"
+          sx={{ fontWeight: "bold", color: "black", mb: 1 }}
+        >
+          {daysOfWeek[dayIndex].label.toUpperCase()}
+        </Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={schedule.attends}
+              onChange={(e) => onAttendsChange(dayIndex, e.target.checked)}
+            />
+          }
+          label="Atiende"
+          sx={{ color: "black" }}
+        />
+      </Box>
+
+      {schedule.attends && (
+        <Box sx={{ flex: 1, display: "flex", flexDirection: "column", gap: 2 }}>
+          {schedule.timeSlots.map((slot, slotIndex) => (
+            <TimeSlotEditor
+              key={slotIndex}
+              slot={slot}
+              slotIndex={slotIndex}
+              dayIndex={dayIndex}
+              canDelete={schedule.timeSlots.length > 1}
+              onTimeChange={onTimeChange}
+              onRemove={onRemoveTimeSlot}
+            />
+          ))}
+          {canAdd && (
+            <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+              <IconButton
+                onClick={() => onAddTimeSlot(dayIndex)}
+                sx={{ color: "#757575" }}
+              >
+                <AddIcon />
+              </IconButton>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default ScheduleDay;

--- a/project-e-dukate-frontend/src/components/ScheduleDay/ScheduleDay.tsx
+++ b/project-e-dukate-frontend/src/components/ScheduleDay/ScheduleDay.tsx
@@ -1,4 +1,3 @@
-// src/components/ScheduleDay/ScheduleDay.tsx
 import React from "react";
 import { Box, Typography, FormControlLabel, Checkbox, IconButton } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";

--- a/project-e-dukate-frontend/src/components/ScheduleDay/index.ts
+++ b/project-e-dukate-frontend/src/components/ScheduleDay/index.ts
@@ -1,0 +1,1 @@
+export { default as ScheduleDay } from "./ScheduleDay";

--- a/project-e-dukate-frontend/src/components/ScheduleForm/ScheduleForm.tsx
+++ b/project-e-dukate-frontend/src/components/ScheduleForm/ScheduleForm.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import { ScheduleDay } from "../ScheduleDay";
+import { Button } from "../Button";
+import { useRouter } from "next/navigation";
+import { ScheduleDto } from "@/types/schedule";
+import { Dayjs } from "dayjs";
+
+interface ScheduleFormProps {
+  specialistName: string;
+  schedules: ScheduleDto[];
+  loading: boolean;
+  onAttendsChange: (dayIndex: number, checked: boolean) => void;
+  onTimeChange: (
+    dayIndex: number,
+    slotIndex: number,
+    field: "startTime" | "endTime",
+    value: Dayjs | null
+  ) => void;
+  onAddTimeSlot: (dayIndex: number) => void;
+  onRemoveTimeSlot: (dayIndex: number, slotIndex: number) => void;
+  onSubmit: () => void;
+}
+
+export const ScheduleForm: React.FC<ScheduleFormProps> = ({
+  specialistName,
+  schedules,
+  loading,
+  onAttendsChange,
+  onTimeChange,
+  onAddTimeSlot,
+  onRemoveTimeSlot,
+  onSubmit,
+}) => {
+  const router = useRouter();
+
+  if (loading) return <Typography>Cargando...</Typography>;
+
+  return (
+    <Box sx={{ px: 30, py: 3 }}>
+      <Typography variant="h4" sx={{ fontWeight: "bold", color: "black", mb: 3 }}>
+        {specialistName}
+      </Typography>
+
+      <Box sx={{ border: "1px solid #e0e0e0", borderRadius: "8px", overflow: "hidden" }}>
+        <Box
+          sx={{
+            bgcolor: "#ffffff",
+            px: 6,
+            py: 3,
+            borderBottom: "1px solid #e0e0e0",
+          }}
+        >
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: "bold", color: "black" }}
+          >
+            Crear Horario
+          </Typography>
+        </Box>
+
+        {schedules.map((schedule, dayIndex) => (
+          <ScheduleDay
+            key={schedule.dayOfWeek}
+            schedule={schedule}
+            dayIndex={dayIndex}
+            onAttendsChange={onAttendsChange}
+            onTimeChange={onTimeChange}
+            onAddTimeSlot={onAddTimeSlot}
+            onRemoveTimeSlot={onRemoveTimeSlot}
+          />
+        ))}
+      </Box>
+
+      <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2, mt: 3 }}>
+        <Button
+          label="Cancelar"
+          onClick={() => router.push("/dashboard/horarios")}
+          variant="outlined"
+        />
+        <Button
+          label="Aceptar"
+          onClick={onSubmit}
+          variant="contained"
+          color="primary"
+          sx={{ bgcolor: "#f5a623", "&:hover": { bgcolor: "#e69520" } }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default ScheduleForm;

--- a/project-e-dukate-frontend/src/components/ScheduleForm/index.ts
+++ b/project-e-dukate-frontend/src/components/ScheduleForm/index.ts
@@ -1,0 +1,1 @@
+export { default as ScheduleForm } from "./ScheduleForm";

--- a/project-e-dukate-frontend/src/components/TimeSlotEditor/TimeSlotEditor.tsx
+++ b/project-e-dukate-frontend/src/components/TimeSlotEditor/TimeSlotEditor.tsx
@@ -1,4 +1,3 @@
-// src/components/TimeSlotEditor/TimeSlotEditor.tsx
 import React from "react";
 import { Box, IconButton } from "@mui/material";
 import { TimePicker } from "@mui/x-date-pickers/TimePicker";

--- a/project-e-dukate-frontend/src/components/TimeSlotEditor/TimeSlotEditor.tsx
+++ b/project-e-dukate-frontend/src/components/TimeSlotEditor/TimeSlotEditor.tsx
@@ -1,0 +1,97 @@
+// src/components/TimeSlotEditor/TimeSlotEditor.tsx
+import React from "react";
+import { Box, IconButton } from "@mui/material";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import DeleteIcon from "@mui/icons-material/Delete";
+import dayjs, { Dayjs } from "dayjs";
+import { TimeSlotDto } from "@/types/schedule";
+
+interface TimeSlotEditorProps {
+  slot: TimeSlotDto;
+  slotIndex: number;
+  dayIndex: number;
+  canDelete: boolean;
+  onTimeChange: (
+    dayIndex: number,
+    slotIndex: number,
+    field: "startTime" | "endTime",
+    value: Dayjs | null
+  ) => void;
+  onRemove: (dayIndex: number, slotIndex: number) => void;
+}
+
+export const TimeSlotEditor: React.FC<TimeSlotEditorProps> = ({
+  slot,
+  slotIndex,
+  dayIndex,
+  canDelete,
+  onTimeChange,
+  onRemove,
+}) => {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 2,
+        borderRadius: "4px",
+        p: 1,
+      }}
+    >
+      <TimePicker
+        label=""
+        value={dayjs(slot.startTime, "HH:mm")}
+        onChange={(value) => onTimeChange(dayIndex, slotIndex, "startTime", value)}
+        ampm={true}
+        slots={{ openPickerIcon: AccessTimeIcon }}
+        sx={{
+          width: "330px",
+          "& .MuiInputBase-root": {
+            borderRadius: "4px",
+            bgcolor: "white",
+            border: "1px solid #e0e0e0",
+            paddingRight: "30px",
+          },
+          "& .MuiInputBase-input": {
+            padding: "8px 14px",
+            fontSize: "14px",
+          },
+          "& .MuiSvgIcon-root": {
+            fontSize: "20px",
+          },
+        }}
+      />
+      <TimePicker
+        label=""
+        value={dayjs(slot.endTime, "HH:mm")}
+        onChange={(value) => onTimeChange(dayIndex, slotIndex, "endTime", value)}
+        ampm={true}
+        slots={{ openPickerIcon: AccessTimeIcon }}
+        sx={{
+          width: "330px",
+          "& .MuiInputBase-root": {
+            borderRadius: "4px",
+            bgcolor: "white",
+            border: "1px solid #e0e0e0",
+            paddingRight: "30px",
+          },
+          "& .MuiInputBase-input": {
+            padding: "8px 14px",
+            fontSize: "14px",
+          },
+          "& .MuiSvgIcon-root": {
+            fontSize: "20px",
+          },
+        }}
+      />
+      {canDelete && (
+        <IconButton onClick={() => onRemove(dayIndex, slotIndex)}>
+          <DeleteIcon sx={{ color: "#757575" }} />
+        </IconButton>
+      )}
+    </Box>
+  );
+};
+
+export default TimeSlotEditor;

--- a/project-e-dukate-frontend/src/components/TimeSlotEditor/index.ts
+++ b/project-e-dukate-frontend/src/components/TimeSlotEditor/index.ts
@@ -1,0 +1,1 @@
+export { default as TimeSlotEditor } from "./TimeSlotEditor";

--- a/project-e-dukate-frontend/src/hooks/useSchedules.ts
+++ b/project-e-dukate-frontend/src/hooks/useSchedules.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// src/hooks/useSchedules.ts
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { fetchSchedules, updateSchedules } from "@/services/scheduleService";
@@ -24,7 +23,7 @@ export const useSchedules = () => {
         const initializedSchedules = initializeSchedules(mappedSchedules);
         setSchedules(initializedSchedules);
       } catch (error) {
-        // Error ya manejado en el servicio con showNotification
+        console.error('Error fetching Schedules details:', error);
       } finally {
         setLoading(false);
       }
@@ -39,7 +38,7 @@ export const useSchedules = () => {
       await updateSchedules(entityId, schedules);
       router.push("/dashboard/horarios");
     } catch (error) {
-      // Error ya manejado en el servicio con showNotification
+      console.error('Error submit details:', error);
     }
   };
 

--- a/project-e-dukate-frontend/src/hooks/useSchedules.ts
+++ b/project-e-dukate-frontend/src/hooks/useSchedules.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// src/hooks/useSchedules.ts
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { fetchSchedules, updateSchedules } from "@/services/scheduleService";
+import { mapBackendSchedules, initializeSchedules } from "@/utils/scheduleUtils";
+import { ScheduleDto } from "@/types/schedule";
+import { useEditStore } from "@/stores/editStore";
+
+export const useSchedules = () => {
+  const router = useRouter();
+  const { entityId } = useEditStore();
+  const [schedules, setSchedules] = useState<ScheduleDto[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const loadSchedules = async () => {
+      if (!entityId) return;
+      setLoading(true);
+      try {
+        const backendSchedules = await fetchSchedules(entityId);
+        const mappedSchedules = mapBackendSchedules(backendSchedules);
+        const initializedSchedules = initializeSchedules(mappedSchedules);
+        setSchedules(initializedSchedules);
+      } catch (error) {
+        // Error ya manejado en el servicio con showNotification
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadSchedules();
+  }, [entityId]);
+
+  const handleSubmit = async () => {
+    if (!entityId) return;
+    try {
+      await updateSchedules(entityId, schedules);
+      router.push("/dashboard/horarios");
+    } catch (error) {
+      // Error ya manejado en el servicio con showNotification
+    }
+  };
+
+  return {
+    schedules,
+    setSchedules,
+    loading,
+    handleSubmit,
+  };
+};

--- a/project-e-dukate-frontend/src/hooks/useSpecialist.ts
+++ b/project-e-dukate-frontend/src/hooks/useSpecialist.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { useState, useEffect } from "react";
+import { fetchSpecialistName } from "@/services/scheduleService";
+import { useEditStore } from "@/stores/editStore";
+
+export const useSpecialist = () => {
+  const { entityId } = useEditStore();
+  const [specialistName, setSpecialistName] = useState<string>("");
+
+  useEffect(() => {
+    const loadSpecialist = async () => {
+      if (!entityId) return;
+      try {
+        const name = await fetchSpecialistName(entityId);
+        setSpecialistName(name);
+      } catch (error) {
+      }
+    };
+
+    loadSpecialist();
+  }, [entityId]);
+
+  return { specialistName };
+};

--- a/project-e-dukate-frontend/src/pages/Schedules/ScheduleEdit.tsx
+++ b/project-e-dukate-frontend/src/pages/Schedules/ScheduleEdit.tsx
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, Checkbox, FormControlLabel, IconButton } from '@mui/material';
+import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { useRouter, useParams } from 'next/navigation';
+import { apiRequest } from '@/services/api';
+import { showNotification } from '@/services/notificationService';
+import { useEditStore } from '@/stores/editStore';
+import { Button } from '@/components/Button';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import dayjs, { Dayjs } from 'dayjs';
+
+interface ScheduleDto {
+  dayOfWeek: string;
+  timeSlots: TimeSlotDto[];
+  attends: boolean;
+}
+
+interface TimeSlotDto {
+  startTime: string;
+  endTime: string;
+}
+
+interface BackendSchedule {
+  specialistId: string;
+  specialist: null;
+  dayOfWeek: number;
+  timeSlots: { startTime: string; endTime: string }[];
+  attends: boolean;
+  id: string;
+}
+
+const dayOfWeekMapping: { [key: number]: string } = {
+  0: 'Sunday',
+  1: 'Monday',
+  2: 'Tuesday',
+  3: 'Wednesday',
+  4: 'Thursday',
+  5: 'Friday',
+  6: 'Saturday',
+};
+
+const daysOfWeek = [
+  { value: 'Monday', label: 'Lunes' },
+  { value: 'Tuesday', label: 'Martes' },
+  { value: 'Wednesday', label: 'Miércoles' },
+  { value: 'Thursday', label: 'Jueves' },
+  { value: 'Friday', label: 'Viernes' },
+  { value: 'Saturday', label: 'Sábado' },
+  { value: 'Sunday', label: 'Domingo' },
+];
+
+export const ScheduleEdit: React.FC = () => {
+  const router = useRouter();
+  useParams();
+  const { entityId } = useEditStore();
+  const [specialistName, setSpecialistName] = useState<string>('');
+  const [schedules, setSchedules] = useState<ScheduleDto[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchSchedules = async () => {
+      if (!entityId) return;
+      setLoading(true);
+      try {
+        const response = await apiRequest<BackendSchedule[]>('schedules', 'GET', undefined, `specialist/${entityId}`);
+        const fetchedSchedules = response.map((schedule: BackendSchedule) => {
+          const dayString = dayOfWeekMapping[schedule.dayOfWeek];
+          if (!dayString) {
+            throw new Error(`Invalid dayOfWeek value: ${schedule.dayOfWeek}`);
+          }
+          return {
+            dayOfWeek: dayString,
+            timeSlots: schedule.timeSlots.map((slot) => ({
+              startTime: slot.startTime.slice(0, 5),
+              endTime: slot.endTime.slice(0, 5),
+            })),
+            attends: schedule.attends,
+          };
+        });
+
+        const allSchedules = daysOfWeek.map((day) => {
+          const existingSchedule = fetchedSchedules.find(
+            (sched: ScheduleDto) => sched.dayOfWeek.toLowerCase() === day.value.toLowerCase()
+          );
+          return existingSchedule || { dayOfWeek: day.value, timeSlots: [], attends: false };
+        });
+
+        setSchedules(allSchedules);
+
+        const specialistResponse = await apiRequest<any>('specialists', 'GET', undefined, entityId);
+        setSpecialistName(`${specialistResponse.names} ${specialistResponse.lastNamePaternal} ${specialistResponse.lastNameMaternal || ''}`);
+      } catch (error) {
+        showNotification('Error al cargar los horarios: ' + (error instanceof Error ? error.message : 'Unknown error'), 'error');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSchedules();
+  }, [entityId]);
+
+  const handleAttendsChange = (dayIndex: number, checked: boolean) => {
+    setSchedules((prev) =>
+      prev.map((sched, idx) =>
+        idx === dayIndex
+          ? { ...sched, attends: checked, timeSlots: checked && sched.timeSlots.length === 0 ? [{ startTime: '08:00', endTime: '12:00' }] : sched.timeSlots }
+          : sched
+      )
+    );
+  };
+
+  const handleTimeChange = (dayIndex: number, slotIndex: number, field: 'startTime' | 'endTime', value: Dayjs | null) => {
+    if (!value) return;
+    const formattedTime = value.format('HH:mm');
+    setSchedules((prev) =>
+      prev.map((sched, idx) =>
+        idx === dayIndex
+          ? {
+              ...sched,
+              timeSlots: sched.timeSlots.map((slot, sIdx) =>
+                sIdx === slotIndex ? { ...slot, [field]: formattedTime } : slot
+              ),
+            }
+          : sched
+      )
+    );
+  };
+
+  const addTimeSlot = (dayIndex: number) => {
+    setSchedules((prev) =>
+      prev.map((sched, idx) =>
+        idx === dayIndex
+          ? { ...sched, timeSlots: [...sched.timeSlots, { startTime: '08:00', endTime: '12:00' }] }
+          : sched
+      )
+    );
+  };
+
+  const removeTimeSlot = (dayIndex: number, slotIndex: number) => {
+    setSchedules((prev) =>
+      prev.map((sched, idx) =>
+        idx === dayIndex
+          ? { ...sched, timeSlots: sched.timeSlots.filter((_, sIdx) => sIdx !== slotIndex) }
+          : sched
+      )
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!entityId) return;
+    try {
+      const payload = schedules.map((sched) => ({
+        dayOfWeek: sched.dayOfWeek,
+        timeSlots: sched.attends
+          ? sched.timeSlots.map((slot) => ({
+              startTime: `${slot.startTime}:00`,
+              endTime: `${slot.endTime}:00`,
+            }))
+          : [],
+        attends: sched.attends,
+      }));
+      await apiRequest('schedules', 'PUT', payload, `specialist/${entityId}`);
+      showNotification('Horarios actualizados con éxito', 'success');
+      router.push('/dashboard/horarios');
+    } catch (error) {
+      showNotification('Error al actualizar los horarios: ' + (error instanceof Error ? error.message : 'Unknown error'), 'error');
+    }
+  };
+
+  if (loading) return <Typography>Cargando...</Typography>;
+
+  return (
+    <Box sx={{ px: 30, py: 3 }}>
+      {/* Título del especialista */}
+      <Typography variant="h4" sx={{ fontWeight: 'bold', color: 'black', mb: 3 }}>
+        {specialistName}
+      </Typography>
+
+      {/* Contenedor de la tabla */}
+      <Box sx={{ border: '1px solid #e0e0e0', borderRadius: '8px', overflow: 'hidden' }}>
+        {/* Encabezado "Crear Horario" */}
+        <Box sx={{ bgcolor: '#ffffff', px: 6, py: 3, borderBottom: '1px solid #e0e0e0' }}>
+          <Typography variant="h6" sx={{ fontWeight: 'bold', color: 'black' }}>
+            Crear Horario
+          </Typography>
+        </Box>
+
+        {/* Lista de días */}
+        {schedules.map((schedule, dayIndex) => (
+          <Box
+            key={schedule.dayOfWeek}
+            sx={{
+              px: 6, 
+              py: 3,
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: schedule.attends ? 'flex-start' : 'center',
+              borderBottom: dayIndex < schedules.length - 1 ? '1px solid #e0e0e0' : 'none',
+              bgcolor: 'white',
+            }}
+          >
+            {/* Sección izquierda: Día y Checkbox */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', width: '330px' }}>
+              <Typography variant="subtitle1" sx={{ fontWeight: 'bold', color: 'black', mb: 1 }}>
+                {daysOfWeek[dayIndex].label.toUpperCase()}
+              </Typography>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={schedule.attends}
+                    onChange={(e) => handleAttendsChange(dayIndex, e.target.checked)}
+                  />
+                }
+                label="Atiende"
+                sx={{ color: 'black' }}
+              />
+            </Box>
+
+            {schedule.attends && (
+              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {schedule.timeSlots.map((slot, slotIndex) => (
+                  <Box
+                    key={slotIndex}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      borderRadius: '4px',
+                      p: 1,
+                    }}
+                  >
+                    <TimePicker
+                      label=""
+                      value={dayjs(slot.startTime, 'HH:mm')}
+                      onChange={(value) => handleTimeChange(dayIndex, slotIndex, 'startTime', value)}
+                      ampm={true}
+                      slots={{
+                        openPickerIcon: AccessTimeIcon,
+                      }}
+                      sx={{
+                        width: '330px',
+                        '& .MuiInputBase-root': {
+                          borderRadius: '4px',
+                          bgcolor: 'white',
+                          border: '1px solid #e0e0e0',
+                          paddingRight: '30px',
+                        },
+                        '& .MuiInputBase-input': {
+                          padding: '8px 14px',
+                          fontSize: '14px',
+                        },
+                        '& .MuiSvgIcon-root': {
+                          fontSize: '20px',
+                        },
+                      }}
+                    />
+                    <TimePicker
+                      label=""
+                      value={dayjs(slot.endTime, 'HH:mm')}
+                      onChange={(value) => handleTimeChange(dayIndex, slotIndex, 'endTime', value)}
+                      ampm={true}
+                      slots={{
+                        openPickerIcon: AccessTimeIcon,
+                      }}
+                      sx={{
+                        width: '330px',
+                        '& .MuiInputBase-root': {
+                          borderRadius: '4px',
+                          bgcolor: 'white',
+                          border: '1px solid #e0e0e0',
+                          paddingRight: '30px',
+                        },
+                        '& .MuiInputBase-input': {
+                          padding: '8px 14px',
+                          fontSize: '14px',
+                        },
+                        '& .MuiSvgIcon-root': {
+                          fontSize: '20px',
+                        },
+                      }}
+                    />
+                    {schedule.timeSlots.length > 1 && (
+                      <IconButton onClick={() => removeTimeSlot(dayIndex, slotIndex)}>
+                        <DeleteIcon sx={{ color: '#757575' }} />
+                      </IconButton>
+                    )}
+                  </Box>
+                ))}
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <IconButton onClick={() => addTimeSlot(dayIndex)} sx={{ color: '#757575' }}>
+                    <AddIcon />
+                  </IconButton>
+                </Box>
+              </Box>
+            )}
+          </Box>
+        ))}
+      </Box>
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, mt: 3 }}>
+        <Button label="Cancelar" onClick={() => router.push('/dashboard/horarios')} variant="outlined" />
+        <Button label="Aceptar" onClick={handleSubmit} variant="contained" color="primary" sx={{ bgcolor: '#f5a623', '&:hover': { bgcolor: '#e69520' } }} />
+      </Box>
+    </Box>
+  );
+};
+
+export default ScheduleEdit;

--- a/project-e-dukate-frontend/src/pages/Schedules/ScheduleEdit.tsx
+++ b/project-e-dukate-frontend/src/pages/Schedules/ScheduleEdit.tsx
@@ -1,123 +1,41 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-"use client";
-
-import React, { useState, useEffect } from 'react';
-import { Box, Typography, Checkbox, FormControlLabel, IconButton } from '@mui/material';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { useRouter, useParams } from 'next/navigation';
-import { apiRequest } from '@/services/api';
-import { showNotification } from '@/services/notificationService';
-import { useEditStore } from '@/stores/editStore';
-import { Button } from '@/components/Button';
-import AddIcon from '@mui/icons-material/Add';
-import DeleteIcon from '@mui/icons-material/Delete';
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import dayjs, { Dayjs } from 'dayjs';
-
-interface ScheduleDto {
-  dayOfWeek: string;
-  timeSlots: TimeSlotDto[];
-  attends: boolean;
-}
-
-interface TimeSlotDto {
-  startTime: string;
-  endTime: string;
-}
-
-interface BackendSchedule {
-  specialistId: string;
-  specialist: null;
-  dayOfWeek: number;
-  timeSlots: { startTime: string; endTime: string }[];
-  attends: boolean;
-  id: string;
-}
-
-const dayOfWeekMapping: { [key: number]: string } = {
-  0: 'Sunday',
-  1: 'Monday',
-  2: 'Tuesday',
-  3: 'Wednesday',
-  4: 'Thursday',
-  5: 'Friday',
-  6: 'Saturday',
-};
-
-const daysOfWeek = [
-  { value: 'Monday', label: 'Lunes' },
-  { value: 'Tuesday', label: 'Martes' },
-  { value: 'Wednesday', label: 'Miércoles' },
-  { value: 'Thursday', label: 'Jueves' },
-  { value: 'Friday', label: 'Viernes' },
-  { value: 'Saturday', label: 'Sábado' },
-  { value: 'Sunday', label: 'Domingo' },
-];
+"use client"
+import React from "react";
+import { ScheduleForm } from "@/components/ScheduleForm";
+import { useSchedules } from "@/hooks/useSchedules";
+import { useSpecialist } from "@/hooks/useSpecialist";
+import { Dayjs } from "dayjs";
+import { calculateNextTimeSlot } from "@/utils/scheduleUtils";
+import { showNotification } from "@/services/notificationService";
 
 export const ScheduleEdit: React.FC = () => {
-  const router = useRouter();
-  useParams();
-  const { entityId } = useEditStore();
-  const [specialistName, setSpecialistName] = useState<string>('');
-  const [schedules, setSchedules] = useState<ScheduleDto[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-
-  useEffect(() => {
-    const fetchSchedules = async () => {
-      if (!entityId) return;
-      setLoading(true);
-      try {
-        const response = await apiRequest<BackendSchedule[]>('schedules', 'GET', undefined, `specialist/${entityId}`);
-        const fetchedSchedules = response.map((schedule: BackendSchedule) => {
-          const dayString = dayOfWeekMapping[schedule.dayOfWeek];
-          if (!dayString) {
-            throw new Error(`Invalid dayOfWeek value: ${schedule.dayOfWeek}`);
-          }
-          return {
-            dayOfWeek: dayString,
-            timeSlots: schedule.timeSlots.map((slot) => ({
-              startTime: slot.startTime.slice(0, 5),
-              endTime: slot.endTime.slice(0, 5),
-            })),
-            attends: schedule.attends,
-          };
-        });
-
-        const allSchedules = daysOfWeek.map((day) => {
-          const existingSchedule = fetchedSchedules.find(
-            (sched: ScheduleDto) => sched.dayOfWeek.toLowerCase() === day.value.toLowerCase()
-          );
-          return existingSchedule || { dayOfWeek: day.value, timeSlots: [], attends: false };
-        });
-
-        setSchedules(allSchedules);
-
-        const specialistResponse = await apiRequest<any>('specialists', 'GET', undefined, entityId);
-        setSpecialistName(`${specialistResponse.names} ${specialistResponse.lastNamePaternal} ${specialistResponse.lastNameMaternal || ''}`);
-      } catch (error) {
-        showNotification('Error al cargar los horarios: ' + (error instanceof Error ? error.message : 'Unknown error'), 'error');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchSchedules();
-  }, [entityId]);
+  const { schedules, setSchedules, loading, handleSubmit } = useSchedules();
+  const { specialistName } = useSpecialist();
 
   const handleAttendsChange = (dayIndex: number, checked: boolean) => {
     setSchedules((prev) =>
       prev.map((sched, idx) =>
         idx === dayIndex
-          ? { ...sched, attends: checked, timeSlots: checked && sched.timeSlots.length === 0 ? [{ startTime: '08:00', endTime: '12:00' }] : sched.timeSlots }
+          ? {
+              ...sched,
+              attends: checked,
+              timeSlots:
+                checked && sched.timeSlots.length === 0
+                  ? [calculateNextTimeSlot([])]
+                  : sched.timeSlots,
+            }
           : sched
       )
     );
   };
 
-  const handleTimeChange = (dayIndex: number, slotIndex: number, field: 'startTime' | 'endTime', value: Dayjs | null) => {
+  const handleTimeChange = (
+    dayIndex: number,
+    slotIndex: number,
+    field: "startTime" | "endTime",
+    value: Dayjs | null
+  ) => {
     if (!value) return;
-    const formattedTime = value.format('HH:mm');
+    const formattedTime = value.format("HH:mm");
     setSchedules((prev) =>
       prev.map((sched, idx) =>
         idx === dayIndex
@@ -133,181 +51,54 @@ export const ScheduleEdit: React.FC = () => {
   };
 
   const addTimeSlot = (dayIndex: number) => {
-    setSchedules((prev) =>
-      prev.map((sched, idx) =>
-        idx === dayIndex
-          ? { ...sched, timeSlots: [...sched.timeSlots, { startTime: '08:00', endTime: '12:00' }] }
-          : sched
-      )
-    );
+    try {
+      setSchedules((prev) =>
+        prev.map((sched, idx) =>
+          idx === dayIndex
+            ? {
+                ...sched,
+                timeSlots: [
+                  ...sched.timeSlots,
+                  calculateNextTimeSlot(sched.timeSlots),
+                ],
+              }
+            : sched
+        )
+      );
+    } catch (error) {
+      showNotification(
+        error instanceof Error
+          ? error.message
+          : "No se pudo agregar el slot.",
+        "error"
+      );
+    }
   };
 
   const removeTimeSlot = (dayIndex: number, slotIndex: number) => {
     setSchedules((prev) =>
       prev.map((sched, idx) =>
         idx === dayIndex
-          ? { ...sched, timeSlots: sched.timeSlots.filter((_, sIdx) => sIdx !== slotIndex) }
+          ? {
+              ...sched,
+              timeSlots: sched.timeSlots.filter((_, sIdx) => sIdx !== slotIndex),
+            }
           : sched
       )
     );
   };
 
-  const handleSubmit = async () => {
-    if (!entityId) return;
-    try {
-      const payload = schedules.map((sched) => ({
-        dayOfWeek: sched.dayOfWeek,
-        timeSlots: sched.attends
-          ? sched.timeSlots.map((slot) => ({
-              startTime: `${slot.startTime}:00`,
-              endTime: `${slot.endTime}:00`,
-            }))
-          : [],
-        attends: sched.attends,
-      }));
-      await apiRequest('schedules', 'PUT', payload, `specialist/${entityId}`);
-      showNotification('Horarios actualizados con éxito', 'success');
-      router.push('/dashboard/horarios');
-    } catch (error) {
-      showNotification('Error al actualizar los horarios: ' + (error instanceof Error ? error.message : 'Unknown error'), 'error');
-    }
-  };
-
-  if (loading) return <Typography>Cargando...</Typography>;
-
   return (
-    <Box sx={{ px: 30, py: 3 }}>
-      {/* Título del especialista */}
-      <Typography variant="h4" sx={{ fontWeight: 'bold', color: 'black', mb: 3 }}>
-        {specialistName}
-      </Typography>
-
-      {/* Contenedor de la tabla */}
-      <Box sx={{ border: '1px solid #e0e0e0', borderRadius: '8px', overflow: 'hidden' }}>
-        {/* Encabezado "Crear Horario" */}
-        <Box sx={{ bgcolor: '#ffffff', px: 6, py: 3, borderBottom: '1px solid #e0e0e0' }}>
-          <Typography variant="h6" sx={{ fontWeight: 'bold', color: 'black' }}>
-            Crear Horario
-          </Typography>
-        </Box>
-
-        {/* Lista de días */}
-        {schedules.map((schedule, dayIndex) => (
-          <Box
-            key={schedule.dayOfWeek}
-            sx={{
-              px: 6, 
-              py: 3,
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: schedule.attends ? 'flex-start' : 'center',
-              borderBottom: dayIndex < schedules.length - 1 ? '1px solid #e0e0e0' : 'none',
-              bgcolor: 'white',
-            }}
-          >
-            {/* Sección izquierda: Día y Checkbox */}
-            <Box sx={{ display: 'flex', flexDirection: 'column', width: '330px' }}>
-              <Typography variant="subtitle1" sx={{ fontWeight: 'bold', color: 'black', mb: 1 }}>
-                {daysOfWeek[dayIndex].label.toUpperCase()}
-              </Typography>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={schedule.attends}
-                    onChange={(e) => handleAttendsChange(dayIndex, e.target.checked)}
-                  />
-                }
-                label="Atiende"
-                sx={{ color: 'black' }}
-              />
-            </Box>
-
-            {schedule.attends && (
-              <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 2 }}>
-                {schedule.timeSlots.map((slot, slotIndex) => (
-                  <Box
-                    key={slotIndex}
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 2,
-                      borderRadius: '4px',
-                      p: 1,
-                    }}
-                  >
-                    <TimePicker
-                      label=""
-                      value={dayjs(slot.startTime, 'HH:mm')}
-                      onChange={(value) => handleTimeChange(dayIndex, slotIndex, 'startTime', value)}
-                      ampm={true}
-                      slots={{
-                        openPickerIcon: AccessTimeIcon,
-                      }}
-                      sx={{
-                        width: '330px',
-                        '& .MuiInputBase-root': {
-                          borderRadius: '4px',
-                          bgcolor: 'white',
-                          border: '1px solid #e0e0e0',
-                          paddingRight: '30px',
-                        },
-                        '& .MuiInputBase-input': {
-                          padding: '8px 14px',
-                          fontSize: '14px',
-                        },
-                        '& .MuiSvgIcon-root': {
-                          fontSize: '20px',
-                        },
-                      }}
-                    />
-                    <TimePicker
-                      label=""
-                      value={dayjs(slot.endTime, 'HH:mm')}
-                      onChange={(value) => handleTimeChange(dayIndex, slotIndex, 'endTime', value)}
-                      ampm={true}
-                      slots={{
-                        openPickerIcon: AccessTimeIcon,
-                      }}
-                      sx={{
-                        width: '330px',
-                        '& .MuiInputBase-root': {
-                          borderRadius: '4px',
-                          bgcolor: 'white',
-                          border: '1px solid #e0e0e0',
-                          paddingRight: '30px',
-                        },
-                        '& .MuiInputBase-input': {
-                          padding: '8px 14px',
-                          fontSize: '14px',
-                        },
-                        '& .MuiSvgIcon-root': {
-                          fontSize: '20px',
-                        },
-                      }}
-                    />
-                    {schedule.timeSlots.length > 1 && (
-                      <IconButton onClick={() => removeTimeSlot(dayIndex, slotIndex)}>
-                        <DeleteIcon sx={{ color: '#757575' }} />
-                      </IconButton>
-                    )}
-                  </Box>
-                ))}
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                  <IconButton onClick={() => addTimeSlot(dayIndex)} sx={{ color: '#757575' }}>
-                    <AddIcon />
-                  </IconButton>
-                </Box>
-              </Box>
-            )}
-          </Box>
-        ))}
-      </Box>
-
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, mt: 3 }}>
-        <Button label="Cancelar" onClick={() => router.push('/dashboard/horarios')} variant="outlined" />
-        <Button label="Aceptar" onClick={handleSubmit} variant="contained" color="primary" sx={{ bgcolor: '#f5a623', '&:hover': { bgcolor: '#e69520' } }} />
-      </Box>
-    </Box>
+    <ScheduleForm
+      specialistName={specialistName}
+      schedules={schedules}
+      loading={loading}
+      onAttendsChange={handleAttendsChange}
+      onTimeChange={handleTimeChange}
+      onAddTimeSlot={addTimeSlot}
+      onRemoveTimeSlot={removeTimeSlot}
+      onSubmit={handleSubmit}
+    />
   );
 };
 

--- a/project-e-dukate-frontend/src/pages/Schedules/Schedules.tsx
+++ b/project-e-dukate-frontend/src/pages/Schedules/Schedules.tsx
@@ -11,6 +11,7 @@ import { useEditStore } from '@/stores/editStore';
 import { TextField } from '../../components/TextField';
 import SearchIcon from '@mui/icons-material/Search';
 import { dayTranslation, formatTimeSlot } from '@/utils/scheduleUtils';
+import slugify from 'slugify';
 
 const getScheduleForDay = (schedules: Schedule[], dayInSpanish: string): string => {
   const dayInEnglish = Object.keys(dayTranslation).find(
@@ -70,7 +71,9 @@ export const Schedules: React.FC = () => {
   const handleEdit = true
     ? (item: Specialist) => {
         setEditData(item.id, 'Specialist', 'user');
-        router.push('/dashboard/usuarios/edit');
+        const specialistName = `${item.names} ${item.lastNamePaternal} ${item.lastNameMaternal || ''}`.toLowerCase();
+        const slug = slugify(specialistName, { lower: true, strict: true });
+        router.push(`/dashboard/horarios/${slug}`);
       }
     : undefined;
 

--- a/project-e-dukate-frontend/src/pages/Schedules/index.ts
+++ b/project-e-dukate-frontend/src/pages/Schedules/index.ts
@@ -1,1 +1,2 @@
 export { default as Schedules } from './Schedules';
+export { default as ScheduleEdit } from './ScheduleEdit';

--- a/project-e-dukate-frontend/src/services/api.ts
+++ b/project-e-dukate-frontend/src/services/api.ts
@@ -4,6 +4,7 @@ export const API_ENDPOINTS = {
   administrators: 'http://localhost:5275/api/Administrators',
   specialists: 'http://localhost:5275/api/Specialists',
   patients: 'http://localhost:5275/api/Patients',
+  schedules: 'http://localhost:5275/api/Schedules',
 };
 
 export const apiRequest = async <T>(

--- a/project-e-dukate-frontend/src/services/api.ts
+++ b/project-e-dukate-frontend/src/services/api.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 export const API_ENDPOINTS = {
   specialties: 'http://localhost:5275/api/Specialties',
   users: 'http://localhost:5275/api/Users',
@@ -25,7 +27,17 @@ export const apiRequest = async <T>(
 
   const response = await fetch(url, options);
   if (!response.ok) {
-    throw new Error(`Error en ${method} a ${url}: ${response.statusText}`);
+    let errorData;
+    try {
+      errorData = await response.json();
+    } catch (e) {
+      errorData = await response.text();
+    }
+    const error = new Error(
+      `Error en ${method} a ${url}: ${response.statusText}`
+    );
+    (error as any).response = { data: errorData, status: response.status };
+    throw error;
   }
 
   return response.status === 204 ? ({} as T) : response.json();

--- a/project-e-dukate-frontend/src/services/scheduleService.ts
+++ b/project-e-dukate-frontend/src/services/scheduleService.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { apiRequest } from "./api";
+import { showNotification } from "./notificationService";
+import { BackendSchedule, ScheduleDto } from "@/types/schedule";
+
+export const fetchSchedules = async (specialistId: string): Promise<BackendSchedule[]> => {
+  try {
+    return await apiRequest<BackendSchedule[]>(
+      "schedules",
+      "GET",
+      undefined,
+      `specialist/${specialistId}`
+    );
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Error al cargar los horarios";
+    showNotification(errorMessage, "error");
+    throw new Error(errorMessage);
+  }
+};
+
+export const updateSchedules = async (
+  specialistId: string,
+  schedules: ScheduleDto[]
+): Promise<void> => {
+  try {
+    const payload = schedules.map((sched) => ({
+      dayOfWeek: sched.dayOfWeek,
+      timeSlots: sched.attends
+        ? sched.timeSlots.map((slot) => ({
+            startTime: `${slot.startTime}:00`,
+            endTime: `${slot.endTime}:00`,
+          }))
+        : [],
+      attends: sched.attends,
+    }));
+    await apiRequest("schedules", "PUT", payload, `specialist/${specialistId}`);
+  } catch (error: any) {
+    let errorMessage = "Error al actualizar los horarios";
+    if (error.response?.data) {
+      if (error.response.data.errors) {
+        errorMessage = error.response.data.errors.join(", ");
+      } else if (typeof error.response.data === "string") {
+        errorMessage = error.response.data;
+      } else {
+        errorMessage = JSON.stringify(error.response.data) || error.message;
+      }
+    } else if (error.message) {
+      errorMessage = error.message;
+    }
+    showNotification(errorMessage, "error");
+    throw new Error(errorMessage);
+  }
+};
+
+export const fetchSpecialistName = async (specialistId: string): Promise<string> => {
+  try {
+    const specialistResponse = await apiRequest<any>(
+      "specialists",
+      "GET",
+      undefined,
+      specialistId
+    );
+    return `${specialistResponse.names} ${specialistResponse.lastNamePaternal} ${
+      specialistResponse.lastNameMaternal || ""
+    }`;
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Error al cargar el especialista";
+    showNotification(errorMessage, "error");
+    throw new Error(errorMessage);
+  }
+};

--- a/project-e-dukate-frontend/src/types/schedule.ts
+++ b/project-e-dukate-frontend/src/types/schedule.ts
@@ -1,0 +1,19 @@
+export interface ScheduleDto {
+  dayOfWeek: string;
+  timeSlots: TimeSlotDto[];
+  attends: boolean;
+}
+
+export interface TimeSlotDto {
+  startTime: string;
+  endTime: string;
+}
+
+export interface BackendSchedule {
+  specialistId: string;
+  specialist: null;
+  dayOfWeek: number;
+  timeSlots: { startTime: string; endTime: string }[];
+  attends: boolean;
+  id: string;
+}

--- a/project-e-dukate-frontend/src/utils/scheduleUtils.ts
+++ b/project-e-dukate-frontend/src/utils/scheduleUtils.ts
@@ -1,4 +1,10 @@
+// src/utils/scheduleUtils.ts
 import { TimeSlot } from "@/types/userTypes";
+import { TimeSlotDto } from "@/types/schedule";
+import dayjs from "dayjs";
+import isBetween from "dayjs/plugin/isBetween";
+
+dayjs.extend(isBetween);
 
 export const dayTranslation: { [key: string]: string } = {
   Monday: "Lunes",
@@ -7,11 +13,125 @@ export const dayTranslation: { [key: string]: string } = {
   Thursday: "Jueves",
   Friday: "Viernes",
   Saturday: "Sábado",
+  Sunday: "Domingo",
 };
+
+export const dayOfWeekMapping: { [key: number]: string } = {
+  0: "Sunday",
+  1: "Monday",
+  2: "Tuesday",
+  3: "Wednesday",
+  4: "Thursday",
+  5: "Friday",
+  6: "Saturday",
+};
+
+export const daysOfWeek = [
+  { value: "Monday", label: "Lunes" },
+  { value: "Tuesday", label: "Martes" },
+  { value: "Wednesday", label: "Miércoles" },
+  { value: "Thursday", label: "Jueves" },
+  { value: "Friday", label: "Viernes" },
+  { value: "Saturday", label: "Sábado" },
+  { value: "Sunday", label: "Domingo" },
+];
 
 export const formatTimeSlot = (timeSlots: TimeSlot[]): string => {
   if (!timeSlots || timeSlots.length === 0) return "-";
   return timeSlots
     .map((slot) => `${slot.startTime} a ${slot.endTime}`)
     .join(", ");
+};
+
+export const mapBackendSchedules = (
+  backendSchedules: import("@/types/schedule").BackendSchedule[]
+): import("@/types/schedule").ScheduleDto[] => {
+  return backendSchedules.map((schedule) => {
+    const dayString = dayOfWeekMapping[schedule.dayOfWeek];
+    if (!dayString) {
+      throw new Error(`Invalid dayOfWeek value: ${schedule.dayOfWeek}`);
+    }
+    return {
+      dayOfWeek: dayString,
+      timeSlots: schedule.timeSlots.map((slot) => ({
+        startTime: slot.startTime.slice(0, 5),
+        endTime: slot.endTime.slice(0, 5),
+      })),
+      attends: schedule.attends,
+    };
+  });
+};
+
+export const initializeSchedules = (
+  fetchedSchedules: import("@/types/schedule").ScheduleDto[]
+): import("@/types/schedule").ScheduleDto[] => {
+  return daysOfWeek.map((day) => {
+    const existingSchedule = fetchedSchedules.find(
+      (sched) => sched.dayOfWeek.toLowerCase() === day.value.toLowerCase()
+    );
+    return existingSchedule || { dayOfWeek: day.value, timeSlots: [], attends: false };
+  });
+};
+
+export const calculateNextTimeSlot = (
+  existingSlots: TimeSlotDto[]
+): TimeSlotDto => {
+  if (existingSlots.length === 0) {
+    return { startTime: "08:00", endTime: "12:00" };
+  }
+
+  const sortedSlots = [...existingSlots].sort((a, b) =>
+    dayjs(a.startTime, "HH:mm").diff(dayjs(b.startTime, "HH:mm"))
+  );
+
+  const lastSlot = sortedSlots[sortedSlots.length - 1];
+  const lastEndTime = dayjs(lastSlot.endTime, "HH:mm");
+
+  const nextStartTime = lastEndTime.add(15, "minute");
+  const nextEndTime = nextStartTime.add(4, "hour");
+
+  const maxEndTime = dayjs("22:00", "HH:mm");
+  if (nextStartTime.isAfter(maxEndTime) || nextEndTime.isAfter(maxEndTime)) {
+    throw new Error("No se pueden agregar más slots: fuera del rango laboral.");
+  }
+
+  const hasOverlap = existingSlots.some((slot) => {
+    const slotStart = dayjs(slot.startTime, "HH:mm");
+    const slotEnd = dayjs(slot.endTime, "HH:mm");
+    return (
+      nextStartTime.isBetween(slotStart, slotEnd, null, "[]") ||
+      nextEndTime.isBetween(slotStart, slotEnd, null, "[]") ||
+      (nextStartTime.isBefore(slotStart) && nextEndTime.isAfter(slotEnd))
+    );
+  });
+
+  if (hasOverlap) {
+    throw new Error("El nuevo slot se superpone con un slot existente.");
+  }
+
+  return {
+    startTime: nextStartTime.format("HH:mm"),
+    endTime: nextEndTime.format("HH:mm"),
+  };
+};
+
+export const canAddTimeSlot = (existingSlots: TimeSlotDto[]): boolean => {
+  if (existingSlots.length === 0) {
+    return true;
+  }
+
+  const sortedSlots = [...existingSlots].sort((a, b) =>
+    dayjs(a.startTime, "HH:mm").diff(dayjs(b.startTime, "HH:mm"))
+  );
+
+  const lastSlot = sortedSlots[sortedSlots.length - 1];
+  const lastEndTime = dayjs(lastSlot.endTime, "HH:mm");
+
+  const nextStartTime = lastEndTime.add(15, "minute");
+  const nextEndTime = nextStartTime.add(4, "hour");
+
+  const maxEndTime = dayjs("22:00", "HH:mm");
+  return !(
+    nextStartTime.isAfter(maxEndTime) || nextEndTime.isAfter(maxEndTime)
+  );
 };

--- a/project-e-dukate-frontend/src/utils/scheduleUtils.ts
+++ b/project-e-dukate-frontend/src/utils/scheduleUtils.ts
@@ -1,4 +1,3 @@
-// src/utils/scheduleUtils.ts
 import { TimeSlot } from "@/types/userTypes";
 import { TimeSlotDto } from "@/types/schedule";
 import dayjs from "dayjs";


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
What was done is that on the schedule screen, when you click the edit schedule button, you can enter the schedule the specialist can work within the care center. You can enter all possible schedules, but if you go past the established schedule until 8 p.m., you will no longer be able to enter any more schedules.
Additionally, you can update their schedules and also delete them if you made a mistake or if they are no longer available during that time.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
You can test it as follows: first, run the command:

```
npm run dev
```

You will see a URL to access the website:

```
http://localhost:3000/dashboard/horarios
```

Upon entering the page, you will see the schedule screen. First, you will see a list of all the specialists. Clicking the update button will redirect you to the schedule screen for each specialist. You will see their current schedules. If not, you can enter, delete, or add schedules. When you finish, click the accept button and you will be redirected to the schedule screen for all specialists, and you will see their entered schedules in the table.