### PR TITLE
feat: add privacy policy screen

### DIFF
--- a/project-e-dukate-frontend/src/app/dashboard/layout.tsx
+++ b/project-e-dukate-frontend/src/app/dashboard/layout.tsx
@@ -36,8 +36,9 @@ export default function DashboardLayout({
             "horarios",
             "metricas",
             "citas",
+            "politica-privacidad",
           ]
-        : ["pacientes", "pagos", "citas"];
+        : ["pacientes", "pagos", "citas", "politica-privacidad"];
 
     const defaultTab = userRole === "Administrator" ? "especialidades" : "pacientes";
 
@@ -52,8 +53,17 @@ export default function DashboardLayout({
     const mainTab = pathSegments[1];
     const validTabs =
       userRole === "Administrator"
-        ? ["especialidades", "usuarios", "pacientes", "pagos", "horarios", "metricas", "citas"]
-        : ["pacientes", "pagos", "citas"];
+        ? [
+            "especialidades",
+            "usuarios",
+            "pacientes",
+            "pagos",
+            "horarios",
+            "metricas",
+            "citas",
+            "politica-privacidad",
+          ]
+        : ["pacientes", "pagos", "citas", "politica-privacidad"];
     
     return validTabs.includes(mainTab) ? mainTab : (userRole === "Administrator" ? "especialidades" : "pacientes");
   };

--- a/project-e-dukate-frontend/src/app/dashboard/politica-privacidad/page.tsx
+++ b/project-e-dukate-frontend/src/app/dashboard/politica-privacidad/page.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import PrivacyPolicy from '@/pages/PrivacyPolicy/PrivacyPolicy';
+
+const PrivacyPolicyPage: React.FC = () => {
+  return <PrivacyPolicy />;
+};
+
+export default PrivacyPolicyPage;

--- a/project-e-dukate-frontend/src/components/Sidebar/Sidebar.tsx
+++ b/project-e-dukate-frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,21 +1,25 @@
 import React, { useState, useRef } from 'react';
-import { 
+import {
   Box,
-  Popper, Paper, ClickAwayListener, Grow, MenuList, MenuItem
+  Popper,
+  Paper,
+  ClickAwayListener,
+  Grow,
+  MenuList,
+  MenuItem,
 } from '@mui/material';
-import { List } from '@mui/material';
-import { ListItemButton } from '@mui/material';
-import { ListItemIcon } from '@mui/material';
+import { List, ListItemButton, ListItemIcon, Tooltip } from '@mui/material';
 import { SxProps } from '@mui/material';
-import { Tooltip } from '@mui/material';
-import { FaStethoscope } from "react-icons/fa";
+import { FaStethoscope } from 'react-icons/fa';
+import { IoSettingsOutline, IoPeopleOutline } from 'react-icons/io5';
+import { MdOutlinePrivacyTip } from 'react-icons/md';
+import { RiFolderChartLine, RiUserHeartLine } from 'react-icons/ri';
 import PeopleAltOutlinedIcon from '@mui/icons-material/PeopleAltOutlined';
-import { RiUserHeartLine } from "react-icons/ri";
 import PaymentsOutlinedIcon from '@mui/icons-material/PaymentsOutlined';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import BarChartIcon from '@mui/icons-material/BarChart';
 import LogoutIcon from '@mui/icons-material/Logout';
-import { LiaBusinessTimeSolid } from "react-icons/lia";
+import { LiaBusinessTimeSolid } from 'react-icons/lia';
 import { useRouter } from 'next/navigation';
 import { useAuthStore } from '../../stores/authStore';
 import { clearAuthToken } from '../../services/api';
@@ -24,6 +28,7 @@ import Image from 'next/image';
 interface SubMenuItem {
   label: string;
   value: string;
+  icon: React.ReactNode;
 }
 
 interface MenuItem {
@@ -43,30 +48,78 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
   const router = useRouter();
   const { userRole, clearAuth } = useAuthStore();
   const [openSubmenu, setOpenSubmenu] = useState(false);
+  const [openSettingsMenu, setOpenSettingsMenu] = useState(false);
   const anchorRef = useRef<HTMLDivElement>(null);
+  const settingsAnchorRef = useRef<HTMLDivElement>(null);
 
   const menuItems: MenuItem[] = [
-    { label: 'Especialidades', icon: <FaStethoscope size={20} />, value: 'especialidades', roles: ['Administrator'] },
-    { label: 'Usuarios', icon: <PeopleAltOutlinedIcon />, value: 'usuarios', roles: ['Administrator'] },
-    { label: 'Pacientes', icon: <RiUserHeartLine size={25} />, value: 'pacientes', roles: ['Administrator', 'Specialist'] },
-    { label: 'Pagos', icon: <PaymentsOutlinedIcon />, value: 'pagos', roles: ['Administrator', 'Specialist'] },
-    { label: "Citas", icon: <CalendarMonthOutlinedIcon />, value: "citas", roles: ['Administrator', 'Specialist'] },
-    { label: 'Horarios', icon: <LiaBusinessTimeSolid size={23} />, value: 'horarios', roles: ['Administrator'] },
-    { 
-      label: 'Metricas', 
-      icon: <BarChartIcon />, 
-      value: 'metricas', 
+    {
+      label: 'Especialidades',
+      icon: <FaStethoscope size={20} />,
+      value: 'especialidades',
+      roles: ['Administrator'],
+    },
+    {
+      label: 'Usuarios',
+      icon: <PeopleAltOutlinedIcon />,
+      value: 'usuarios',
+      roles: ['Administrator'],
+    },
+    {
+      label: 'Pacientes',
+      icon: <RiUserHeartLine size={25} />,
+      value: 'pacientes',
+      roles: ['Administrator', 'Specialist'],
+    },
+    {
+      label: 'Pagos',
+      icon: <PaymentsOutlinedIcon />,
+      value: 'pagos',
+      roles: ['Administrator', 'Specialist'],
+    },
+    {
+      label: 'Citas',
+      icon: <CalendarMonthOutlinedIcon />,
+      value: 'citas',
+      roles: ['Administrator', 'Specialist'],
+    },
+    {
+      label: 'Horarios',
+      icon: <LiaBusinessTimeSolid size={23} />,
+      value: 'horarios',
+      roles: ['Administrator'],
+    },
+    {
+      label: 'Metricas',
+      icon: <BarChartIcon />,
+      value: 'metricas',
       roles: ['Administrator'],
       subItems: [
-        { label: 'Historial médico', value: 'metricas/historial-medico' },
-        { label: 'Demografía', value: 'metricas/demografia' },
-        { label: 'Pagos', value: 'metricas/pagos' }
-      ]
+        {
+          label: 'Historial médico',
+          value: 'metricas/historial-medico',
+          icon: <RiFolderChartLine size={20} />,
+        },
+        {
+          label: 'Demografía',
+          value: 'metricas/demografia',
+          icon: <IoPeopleOutline size={20} />,
+        },
+        {
+          label: 'Pagos',
+          value: 'metricas/pagos',
+          icon: <PaymentsOutlinedIcon />,
+        },
+      ],
     },
   ];
 
   const handleToggleSubmenu = () => {
     setOpenSubmenu((prevOpen) => !prevOpen);
+  };
+
+  const handleToggleSettingsMenu = () => {
+    setOpenSettingsMenu((prevOpen) => !prevOpen);
   };
 
   const handleCloseSubmenu = (event: Event | React.SyntheticEvent) => {
@@ -76,9 +129,24 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
     setOpenSubmenu(false);
   };
 
+  const handleCloseSettingsMenu = (event: Event | React.SyntheticEvent) => {
+    if (
+      settingsAnchorRef.current &&
+      settingsAnchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+    setOpenSettingsMenu(false);
+  };
+
   const handleSubitemClick = (value: string) => {
     router.push(`/dashboard/${value}`);
     setOpenSubmenu(false);
+  };
+
+  const handlePrivacyPolicyClick = () => {
+    router.push('/dashboard/politica-privacidad');
+    setOpenSettingsMenu(false);
   };
 
   const handleLogout = () => {
@@ -87,12 +155,23 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
     router.push('/login');
   };
 
-  const filteredMenuItems = menuItems.filter(item => 
+  const filteredMenuItems = menuItems.filter((item) =>
     userRole && item.roles.includes(userRole)
   );
 
   return (
-    <Box sx={{ width: 120, height: '100vh', bgcolor: '#013c28', color: 'white', display: 'flex', flexDirection: 'column', justifyContent: 'space-between', ...sx }}>
+    <Box
+      sx={{
+        width: 120,
+        height: '100vh',
+        bgcolor: '#013c28',
+        color: 'white',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        ...sx,
+      }}
+    >
       <Box>
         <Box sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
           <Image
@@ -153,14 +232,14 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
                 >
                   {({ TransitionProps }) => (
                     <Grow {...TransitionProps}>
-                      <Paper 
-                        sx={{ 
-                          bgcolor: 'white', 
+                      <Paper
+                        sx={{
+                          bgcolor: 'white',
                           color: 'black',
                           borderRadius: 2,
                           boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.25)',
                           overflow: 'hidden',
-                          ml: 1
+                          ml: 1,
                         }}
                       >
                         <ClickAwayListener onClickAway={handleCloseSubmenu}>
@@ -178,6 +257,15 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
                                   }),
                                 }}
                               >
+                                <ListItemIcon
+                                  sx={{
+                                    color: selectedTab === subItem.value ? '#04633c' : 'black',
+                                    minWidth: 0,
+                                    mr: 1,
+                                  }}
+                                >
+                                  {subItem.icon}
+                                </ListItemIcon>
                                 {subItem.label}
                               </MenuItem>
                             ))}
@@ -193,7 +281,87 @@ export const Sidebar: React.FC<SidebarProps> = ({ selectedTab, sx }) => {
         </List>
       </Box>
       <List>
-        <Tooltip title="Cerrar Sesion" placement="right">
+        <Tooltip title="Configuración" placement="right">
+          <ListItemButton
+            ref={settingsAnchorRef}
+            onClick={handleToggleSettingsMenu}
+            sx={{
+              mx: 2,
+              borderRadius: 2,
+              justifyContent: 'center',
+              bgcolor: selectedTab === 'politica-privacidad' ? 'white' : 'transparent',
+              color: selectedTab === 'politica-privacidad' ? '#04633c' : 'white',
+              '&:hover': { bgcolor: selectedTab === 'politica-privacidad' ? 'white' : 'rgba(255, 255, 255, 0.1)' },
+              ...(selectedTab === 'politica-privacidad' && {
+                '&::before': {
+                  content: '""',
+                  position: 'absolute',
+                  left: -16,
+                  top: 0,
+                  bottom: 0,
+                  width: 4,
+                  bgcolor: 'white',
+                  borderRadius: '0 2px 2px 0',
+                },
+              }),
+            }}
+          >
+            <ListItemIcon
+              sx={{
+                color: selectedTab === 'politica-privacidad' ? '#04633c' : 'white',
+                minWidth: 0,
+              }}
+            >
+              <IoSettingsOutline size={24} />
+            </ListItemIcon>
+          </ListItemButton>
+        </Tooltip>
+        <Popper
+          open={openSettingsMenu}
+          anchorEl={settingsAnchorRef.current}
+          role={undefined}
+          placement="right-start"
+          transition
+          disablePortal
+          sx={{ zIndex: 1200 }}
+        >
+          {({ TransitionProps }) => (
+            <Grow {...TransitionProps}>
+              <Paper
+                sx={{
+                  bgcolor: 'white',
+                  color: 'black',
+                  borderRadius: 2,
+                  boxShadow: '0px 4px 20px rgba(0, 0, 0, 0.25)',
+                  overflow: 'hidden',
+                  ml: 1,
+                }}
+              >
+                <ClickAwayListener onClickAway={handleCloseSettingsMenu}>
+                  <MenuList autoFocusItem={openSettingsMenu}>
+                    <MenuItem
+                      onClick={handlePrivacyPolicyClick}
+                      sx={{
+                        color: 'black',
+                        '&:hover': { bgcolor: 'rgba(1, 60, 40, 0.1)' },
+                        ...(selectedTab === 'politica-privacidad' && {
+                          bgcolor: 'white',
+                          color: '#04633c',
+                        }),
+                      }}
+                    >
+                      <ListItemIcon sx={{ color: 'black', minWidth: 0, mr: 1 }}>
+                        <MdOutlinePrivacyTip size={20} />
+                      </ListItemIcon>
+                      Políticas de Privacidad
+                    </MenuItem>
+                  </MenuList>
+                </ClickAwayListener>
+              </Paper>
+            </Grow>
+          )}
+        </Popper>
+        <Tooltip title="Cerrar Sesión" placement="right">
           <ListItemButton
             onClick={handleLogout}
             sx={{

--- a/project-e-dukate-frontend/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/project-e-dukate-frontend/src/pages/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Box, Typography, Container, Divider } from '@mui/material';
+
+const PrivacyPolicy: React.FC = () => {
+  return (
+    <Container maxWidth="xl" sx={{ py: 5 }}>
+      <Box sx={{ bgcolor: 'white', p: 4, borderRadius: 2, boxShadow: 3 }}>
+        <Typography variant="h4" gutterBottom>
+          Políticas de Privacidad
+        </Typography>
+        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+          Última actualización: 26 de agosto de 2025
+        </Typography>
+        <Divider sx={{ my: 2 }} />
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          1. Introducción
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          En E-Dukate el Centro de Atención, Evaluación e Intervención en Trastornos del Neurodesarrollo y Salud Mental, dirigido por la Mgr. Lourdes Tupa Lima, Master en Discapacidad y Certificada para Diagnóstico de Autismo, nos comprometemos a proteger la privacidad de nuestros pacientes y sus familias. Esta Política de Privacidad describe cómo recopilamos, usamos, almacenamos y protegemos tu información personal.
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          2. Información que Recopilamos
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          Recopilamos los siguientes tipos de información:
+          <ul>
+            <li><strong>Datos personales:</strong> Nombre, número de teléfono, correo electrónico, dirección y, en su caso, datos de tutores legales.</li>
+            <li><strong>Datos médicos:</strong> Historial clínico, diagnósticos, informes de evaluación (por ejemplo, relacionados con autismo u otros trastornos) y registros de citas.</li>
+            <li><strong>Datos de menores:</strong> Información proporcionada por padres o tutores legales para tratamientos en psicología, fonoaudiología, fisioterapia, nutrición u otros servicios.</li>
+          </ul>
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          3. Cómo Usamos tu Información
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          Utilizamos tus datos para:
+          <ul>
+            <li>Coordinar citas y proporcionar servicios de psicología, fonoaudiología, fisioterapia, nutrición y otros.</li>
+            <li>Realizar evaluaciones y diagnósticos, como los relacionados con trastornos del neurodesarrollo.</li>
+            <li>Contactarte para recordatorios de citas o seguimientos.</li>
+            <li>Cumplir con obligaciones legales o normativas de salud en Bolivia.</li>
+          </ul>
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          4. Compartir tu Información
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          No compartimos tus datos personales con terceros, salvo en los siguientes casos:
+          <ul>
+            <li>Con especialistas externos (por ejemplo, laboratorios o médicos referidos), previa autorización del paciente o tutor legal.</li>
+            <li>Con autoridades legales, si así lo exige la normativa boliviana.</li>
+          </ul>
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          5. Seguridad de los Datos
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          Implementamos medidas de seguridad físicas y digitales, como almacenamiento seguro de expedientes médicos y acceso restringido a datos, para proteger tu información. Nos aseguramos de cumplir con las normativas de confidencialidad en el ámbito de la salud.
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          6. Tus Derechos
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          De acuerdo con la normativa boliviana, tienes derecho a:
+          <ul>
+            <li>Acceder a tus datos personales o los de tu hijo/a bajo tu tutela.</li>
+            <li>Solicitar la corrección o eliminación de datos inexactos.</li>
+            <li>Retirar tu consentimiento para el uso de datos, salvo en casos requeridos por ley.</li>
+          </ul>
+          Para ejercer estos derechos, contáctanos en los datos proporcionados en la sección de contacto.
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          7. Cambios a esta Política
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          Podemos actualizar esta política periódicamente. Cualquier cambio será comunicado en nuestro sitio web o directamente a los pacientes, si es necesario.
+        </Typography>
+
+        <Typography sx={{ fontWeight: "bold" }} variant="h6" gutterBottom>
+          8. Contacto
+        </Typography>
+        <Typography component="div" sx={{ mb: 2 }}>
+          Si tienes preguntas sobre esta Política de Privacidad, contáctanos en:
+          <ul>
+            <li><strong>Teléfono:</strong> +591 76440737</li>
+            <li><strong>Dirección:</strong> Calle Potosí, entre Uyuni y pasaje 1 de Abril, Cochabamba, Bolivia</li>
+          </ul>
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+          © 2025 Centro de Atención, Evaluación e Intervención en Trastornos del Neurodesarrollo y Salud Mental. Todos los derechos reservados.
+        </Typography>
+      </Box>
+    </Container>
+  );
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
# Pull Request Template 🚀

## 📝 Description
This pull request adds the "Políticas de Privacidad" (Privacy Policy) navigation option to the Sidebar component. A new menu item under the "Configuración" (Settings) section allows users to access the privacy policy page by navigating to /dashboard/politica-privacidad. The feature includes a clickable menu item in the settings submenu that triggers the navigation when selected.

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## 🧪 How Has This Been Tested?
To verify the changes, navigate to `http://localhost:3000/dashboard/politica-privacidad`. You will see the text content of the privacy policy page displayed.

## ✅ Checklist
- [X] 🔎 I have performed a self-review of my own code
- [X] 🚫 My changes generate no new warnings